### PR TITLE
Duplicate freetype dependency on harfbuzz is causing problems for build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,12 +28,6 @@ pub fn build(b: *std.Build) void {
         lib.root_module.addCMacro("TTF_USE_HARFBUZZ", "");
     }
 
-    const freetype_dep = b.dependency("freetype", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    lib.linkLibrary(freetype_dep.artifact("freetype"));
-
     const sdl_dep = b.dependency("SDL", .{
         .target = target,
         .optimize = optimize,

--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,6 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const harfbuzz_enabled = b.option(bool, "enable-harfbuzz", "Use HarfBuzz to improve text shaping") orelse false;
 
     const upstream = b.dependency("SDL_ttf", .{});
 
@@ -18,15 +17,6 @@ pub fn build(b: *std.Build) void {
         }),
     });
     lib.addCSourceFile(.{ .file = upstream.path("SDL_ttf.c") });
-
-    if (harfbuzz_enabled) {
-        const harfbuzz_dep = b.dependency("harfbuzz", .{
-            .target = target,
-            .optimize = optimize,
-        });
-        lib.linkLibrary(harfbuzz_dep.artifact("harfbuzz"));
-        lib.root_module.addCMacro("TTF_USE_HARFBUZZ", "");
-    }
 
     const freetype_dep = b.dependency("freetype", .{
         .target = target,

--- a/build.zig
+++ b/build.zig
@@ -28,6 +28,12 @@ pub fn build(b: *std.Build) void {
         lib.root_module.addCMacro("TTF_USE_HARFBUZZ", "");
     }
 
+    const freetype_dep = b.dependency("freetype", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    lib.linkLibrary(freetype_dep.artifact("freetype"));
+
     const sdl_dep = b.dependency("SDL", .{
         .target = target,
         .optimize = optimize,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,6 +8,10 @@
             .url = "git+https://github.com/allyourcodebase/harfbuzz#d642b5da200481be30a2e3518e7716722079d6a5",
             .hash = "harfbuzz-8.4.0-AAAAAESZAABw9XXl0lM3Ohy0A1IRj1m1k0hYoXg3Ct0t",
         },
+        .freetype = .{
+            .url = "git+https://github.com/allyourcodebase/freetype#d0a748192f26bd20f9f339d0d7156b84e90eb4dc",
+            .hash = "freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms",
+        },
         .SDL = .{
             .url = "git+https://github.com/allyourcodebase/SDL#181dd2c6a69a8392a8457a5e80e3ab2e4871e643",
             .hash = "SDL-2.32.4-JToi30-TEgH42-HFmgINmgFPrAXOjaNp734Jh_wep6ZN",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,10 +8,6 @@
             .url = "git+https://github.com/allyourcodebase/harfbuzz#d642b5da200481be30a2e3518e7716722079d6a5",
             .hash = "harfbuzz-8.4.0-AAAAAESZAABw9XXl0lM3Ohy0A1IRj1m1k0hYoXg3Ct0t",
         },
-        .freetype = .{
-            .url = "git+https://github.com/allyourcodebase/freetype#d0a748192f26bd20f9f339d0d7156b84e90eb4dc",
-            .hash = "freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms",
-        },
         .SDL = .{
             .url = "git+https://github.com/allyourcodebase/SDL#181dd2c6a69a8392a8457a5e80e3ab2e4871e643",
             .hash = "SDL-2.32.4-JToi30-TEgH42-HFmgINmgFPrAXOjaNp734Jh_wep6ZN",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,10 +4,6 @@
     .fingerprint = 0xa98f7681c4b9d53c,
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
-        .harfbuzz = .{
-            .url = "git+https://github.com/allyourcodebase/harfbuzz#d642b5da200481be30a2e3518e7716722079d6a5",
-            .hash = "harfbuzz-8.4.0-AAAAAESZAABw9XXl0lM3Ohy0A1IRj1m1k0hYoXg3Ct0t",
-        },
         .freetype = .{
             .url = "git+https://github.com/allyourcodebase/freetype#d0a748192f26bd20f9f339d0d7156b84e90eb4dc",
             .hash = "freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms",


### PR DESCRIPTION
As seen on:
https://github.com/allyourcodebase/SDL_ttf/actions/runs/14289239312/job/40048300645:
```
/Users/runner/.cache/zig/p/freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms/build.zig:1:1: error: file exists in multiple modules
/Users/runner/.cache/zig/p/freetype-2.13.2-AAAAAByJAAD[7](https://github.com/allyourcodebase/SDL_ttf/actions/runs/14289239312/job/40048300645#step:6:8)KQxAcdDYidJ3YigvRztfnLmn4rQpvLms/build.zig:1:1: note: root of module root.@dependencies.freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms
/Users/runner/.cache/zig/p/freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms/build.zig:1:1: note: root of module root.@dependencies.1220fb290c4071d0d[8](https://github.com/allyourcodebase/SDL_ttf/actions/runs/14289239312/job/40048300645#step:6:9)89d27762282f473b5f9cb9a7e2b429bcb9acbd9172a6e2a1e4
```

I am not entirely sure on how to go about this. I am not very familiar with zig build system. Removing harfbuzz altogether fixes the problem but surely there is a better fix?
