### PR TITLE
Add preferred_linkage build option to support static/dynamic linking.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,10 +7,16 @@ pub fn build(b: *std.Build) void {
 
     const upstream = b.dependency("SDL_ttf", .{});
 
+    const preferred_linkage = b.option(
+        std.builtin.LinkMode,
+        "preferred_linkage",
+        "Prefer building statically or dynamically linked libraries (default: static)",
+    ) orelse .static;
+
     const lib = b.addLibrary(.{
         .name = "SDL3_ttf",
         .version = .{ .major = 3, .minor = 2, .patch = 2 },
-        .linkage = .static,
+        .linkage = preferred_linkage,
         .root_module = b.createModule(.{
             .target = target,
             .optimize = optimize,
@@ -42,6 +48,7 @@ pub fn build(b: *std.Build) void {
     const sdl = b.dependency("SDL", .{
         .target = target,
         .optimize = optimize,
+        .preferred_linkage = preferred_linkage,
     }).artifact("SDL3");
     lib.linkLibrary(sdl);
 


### PR DESCRIPTION
## Description
This change introduces a preferred_linkage build option, similar to [castholm/SDL](https://github.com/castholm/SDL/blob/fce122b6b1e963285b3359f95a1bfe876afc20a6/build.zig#L14C5-L22C22).
It allows consumers of the library to choose between static or dynamic linkage for the resulting artifact.

## Motivation
In my project, I use hot-reloadable dynamic libraries. To avoid multiple statically linked versions of shared dependencies (e.g., SDL, SDL_ttf) across packages, I need to dynamically link them. This option makes that possible.